### PR TITLE
Fixes keygen and removes redundant communication

### DIFF
--- a/src/keygen_state_machine.rs
+++ b/src/keygen_state_machine.rs
@@ -382,14 +382,13 @@ where
     M: Mpc<ProtocolMessage = Msg>,
 {
     let key_share = round5_broadcast_data.as_uncompressed_bytes().to_vec();
-    let mut my_broadcast = Msg5 {
+    let my_broadcast = Msg5 {
         source: i,
         data: key_share,
     };
     let broadcast_msg = Msg::Round5Broadcast(my_broadcast.clone());
     send_message::<M, Msg>(broadcast_msg.clone(), tx).await?;
 
-    my_broadcast.source += 1; // adjust for 1-indexed gennaro
     let round5_broadcasts = rounds
         .complete(round5)
         .await

--- a/src/signing_state_machine.rs
+++ b/src/signing_state_machine.rs
@@ -14,8 +14,6 @@ use crate::signing::SigningError;
 pub struct BlsSigningState {
     pub secret_key: Option<SecretKey>,
     pub signature: Option<Vec<u8>>,
-    pub public_key: Option<Vec<u8>>,
-    received_pk_shares: BTreeMap<usize, PublicKey>,
     received_sig_shares: BTreeMap<usize, Signature>,
 }
 
@@ -28,7 +26,7 @@ pub enum Msg {
 pub struct Msg1 {
     pub sender: u16,
     pub receiver: Option<u16>,
-    pub body: (Vec<u8>, Vec<u8>), // (signature_share, public_key_share)
+    pub body: Vec<u8>, // signature_share
 }
 
 pub async fn bls_signing_protocol<M, T>(
@@ -64,12 +62,11 @@ where
     // Step 1: Generate shares
     let sign_input = gadget_sdk::compute_sha256_hash!(input_data_to_sign.as_ref());
     let sig_share = Signature::new(&sign_input, &secret_key);
-    let pk_share = PublicKey::from_secret_key(&secret_key);
 
     let my_msg = Msg1 {
         sender: i,
         receiver: None,
-        body: (sig_share.as_bytes().to_vec(), pk_share.as_bytes().to_vec()),
+        body: sig_share.as_bytes().to_vec(),
     };
     // Step 2: Broadcast shares
     let msg = Msg::Round1Broadcast(my_msg.clone());
@@ -89,12 +86,9 @@ where
         .map_err(|e| SigningError::MpcError(format!("Failed to complete round: {}", e)))?;
 
     for msg in msgs.into_vec_including_me(my_msg) {
-        let (sender, (sig, pk)) = (msg.sender, msg.body);
-        let pk = PublicKey::from_bytes(&pk)
-            .map_err(|e| SigningError::MpcError(format!("Failed to create public key: {e:?}")))?;
+        let (sender, sig) = (msg.sender, msg.body);
         let sig = Signature::from_bytes(&sig)
             .map_err(|e| SigningError::MpcError(format!("Failed to create signature: {e:?}")))?;
-        signing_state.received_pk_shares.insert(sender as usize, pk);
         signing_state
             .received_sig_shares
             .insert(sender as usize, sig);
@@ -109,27 +103,15 @@ where
         .map(|r| r.1)
         .collect::<Vec<_>>();
 
-    let pk_shares = signing_state
-        .received_pk_shares
-        .clone()
-        .into_iter()
-        .sorted_by_key(|r| r.0)
-        .map(|r| r.1)
-        .collect::<Vec<_>>();
-
     let combined_signature = snowbridge_milagro_bls::AggregateSignature::aggregate(
         &sig_shares.iter().collect::<Vec<_>>(),
     );
 
-    let pk_agg = snowbridge_milagro_bls::AggregatePublicKey::aggregate(
-        &pk_shares.iter().collect::<Vec<_>>(),
-    )
-    .map_err(|e| SigningError::MpcError(format!("Failed to aggregate public keys: {e:?}")))?;
+    let uncompressed_pk = state.uncompressed_pk.as_ref().ok_or_else(|| {
+        SigningError::KeyRetrievalError("Uncompressed public key not found in state".to_string())
+    })?;
 
-    let mut input = [0u8; 97];
-    pk_agg.point.to_bytes(&mut input, false);
-
-    let as_pk = PublicKey::from_uncompressed_bytes(&input[1..])
+    let as_pk = PublicKey::from_uncompressed_bytes(&uncompressed_pk[1..])
         .map_err(|e| SigningError::MpcError(format!("Failed to create public key: {e:?}")))?;
 
     let as_sig = Signature::from_bytes(&combined_signature.as_bytes())
@@ -141,7 +123,6 @@ where
         ));
     }
 
-    signing_state.public_key = Some(as_pk.as_uncompressed_bytes().to_vec());
     signing_state.signature = Some(as_sig.as_bytes().to_vec());
     signing_state.secret_key = Some(secret_key);
 


### PR DESCRIPTION
Applies the fix outlined in #8 and trims down redundant communication of `pk_shares` during the signing phase